### PR TITLE
Enable CI for dotnet-vnext

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     - '**/*.gitignore'
     - '**/*.gitattributes'
   pull_request:
-    branches: [ main ]
+    branches: [ main, dotnet-vnext ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Also run CI builds for the `dotnet-vnext` branch.